### PR TITLE
feat: build wasi binary

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,5 +50,6 @@ jobs:
           lenv-freebsd-arm64
           lenv-openbsd-amd64
           lenv-openbsd-arm64
+          lenv-wasip1.wasm
           LICENSE
         body: ${{ env.changelog }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ lenv-freebsd-amd64
 lenv-freebsd-arm64
 lenv-openbsd-amd64
 lenv-openbsd-arm64
+lenv-wasip1.wasm

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ build: deps
 	GOOS=freebsd GOARCH=arm64 go build -ldflags="-s -w" -trimpath -o lenv-freebsd-arm64 ./cmd/lenv/main.go
 	GOOS=openbsd GOARCH=amd64 go build -ldflags="-s -w" -trimpath -o lenv-openbsd-amd64 ./cmd/lenv/main.go
 	GOOS=openbsd GOARCH=arm64 go build -ldflags="-s -w" -trimpath -o lenv-openbsd-arm64 ./cmd/lenv/main.go
+	GOOS=wasip1 GOARCH=wasm go build -ldflags="-s -w" -trimpath -o lenv-wasip1.wasm ./cmd/lenv/main.go

--- a/lenv.go
+++ b/lenv.go
@@ -83,7 +83,11 @@ func Check(source string, destinations []string) error {
 			if err != nil {
 				panic(err)
 			}
-			if link == source {
+			relSource, err := filepath.Rel(filepath.Dir(destination), source)
+			if err != nil {
+				return fmt.Errorf("lenv: failed to get relative path from %s to %s", destination, source)
+			}
+			if link == relSource {
 				fmt.Printf("lenv: symlink links %s to %s\n", source, destination)
 			} else {
 				return fmt.Errorf("lenv: symlink %s does not link to %s, it should be removed", destination, source)
@@ -119,8 +123,11 @@ func Link(source string, destinations []string) error {
 				return fmt.Errorf("lenv: physical file at %s should be removed first", destination)
 			}
 		}
-
-		err = os.Symlink(source, destination)
+		relSource, err := filepath.Rel(filepath.Dir(destination), source)
+		if err != nil {
+			return fmt.Errorf("lenv: failed to get relative path from %s to %s", destination, source)
+		}
+		err = os.Symlink(relSource, destination)
 		if err != nil {
 			return fmt.Errorf("lenv: failed to symlink %s to %s", source, destination)
 		}


### PR DESCRIPTION
This PR:

- Adjusts symlink logic to use relative paths to accommodate [WASI security limitation preventing absolute paths](https://github.com/WebAssembly/wasi-filesystem/blob/8df08e665e462e9f0618c64496d5ffe71c0f0c62/path-resolution.md?plain=1#L33-L34)
- Builds the WASI binary and uploads with release

Notes:

- Tested with the [Wasmtime](https://wasmtime.dev/) runtime using this command structure:

```sh
wasmtime --wasi cli --dir /path/to/your/project/root lenv-wasip1.wasm check|link|unlink
```